### PR TITLE
Replaced obsolete jcenter repo with gradlePluginPortal. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         mavenCentral()
         mavenLocal()
-        jcenter()
+        gradlePluginPortal()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.0"
@@ -17,8 +17,6 @@ allprojects {
     repositories {
         mavenCentral()
         mavenLocal()
-        jcenter()
-        maven { url "https://dl.bintray.com/kotlin/kotlinx" }
         maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
I verified that I can run Main (and SomeClass, though it doesn't appear to do anything). IntelliJ still issues a warning because the kotlin-gradle-plugin version is old, but it does not prevent the build from working.

Signed-off-by: DenalidTX

Looks like this after build update:
![image](https://user-images.githubusercontent.com/93103397/160265518-93708206-8c38-4468-a23c-abe164a89f23.png)
